### PR TITLE
Update pub-sub package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -978,9 +978,9 @@
       }
     },
     "@ictoanen/pub-sub": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ictoanen/pub-sub/-/pub-sub-2.0.0.tgz",
-      "integrity": "sha512-qX8JfajX0ZQ3Pg6B4RUHUoe6yhchcrK8dQijk8FoxLBsQ1cemJ0tKllp8rVQWavpdBVOkgMM+9RZmNsx3SEXWg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@ictoanen/pub-sub/-/pub-sub-2.1.0.tgz",
+      "integrity": "sha512-rY3mEQnhbEUTFsnvjx9AAX3lC333IqpoyD53hcx4xNjEUEjNnf9fb4/rYeCgWDSaCdmD/XQipLz45EdczDjDsQ==",
       "dev": true
     },
     "@istanbuljs/load-nyc-config": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@babel/core": "^7.8.7",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/preset-env": "^7.8.7",
-    "@ictoanen/pub-sub": "^2.0.0",
+    "@ictoanen/pub-sub": "^2.1.0",
     "babel-jest": "^25.1.0",
     "jest": "^25.1.0"
   }


### PR DESCRIPTION
Updates the dependency on the pub-sub package from version 2.0.0 to
version 2.1.0. The new version includes an ES5 compatible version which
ensures the Jest unit tests will run properly.